### PR TITLE
exclude transitive dependencies from spring boot

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,6 +94,8 @@ dependencies {
 
 configurations {
     compile.exclude(module: 'spring-boot-starter-tomcat')
+	compile.exclude(module: 'spring-webmvc')
+    compile.exclude(module: 'commons-logging')
 }
 
 springBoot {

--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,7 @@ dependencies {
 
 configurations {
     compile.exclude(module: 'spring-boot-starter-tomcat')
-	compile.exclude(module: 'spring-webmvc')
+    compile.exclude(module: 'spring-webmvc')
     compile.exclude(module: 'commons-logging')
 }
 


### PR DESCRIPTION
Exclude 'spring-webmvc' and 'commons-logging' from spring boot 
