### PR TITLE
Issue 40 - Update Spring Boot and camel to latest versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,14 +13,15 @@ buildscript {
         }
     }
     dependencies {
-        classpath("org.springframework.boot:spring-boot-gradle-plugin:1.3.1.RELEASE")
+        classpath("org.springframework.boot:spring-boot-gradle-plugin:1.4.3.RELEASE")
+        classpath 'com.netflix.nebula:nebula-release-plugin:4.1.1'
     }
 }
 
 apply plugin: 'java'
 apply plugin: 'idea'
 apply plugin: 'maven'
-apply plugin: 'spring-boot'
+apply plugin: 'org.springframework.boot'
 
 jar {
     baseName = 'camel-boot'
@@ -35,8 +36,8 @@ repositories {
     }
 }
 
-def springBootVersion = '1.3.1.RELEASE'
-def camelVersion = '2.16.2'
+def springBootVersion = '1.4.3.RELEASE'
+def camelVersion = '2.18.1'
 
 sourceSets {
     integrationTest {
@@ -80,21 +81,22 @@ dependencies {
         exclude group: 'ch.qos.logback', module: 'logback-classic'
     }
     compile(group: 'org.springframework.boot', name: 'spring-boot-starter-jetty',          version: springBootVersion)
-    compile(group: 'com.netflix.hystrix',      name: 'hystrix-metrics-event-stream',       version: '1.3.16')
+    compile(group: 'com.netflix.hystrix',      name: 'hystrix-core',                       version: '1.5.8')
+    compile(group: 'com.netflix.hystrix',      name: 'hystrix-metrics-event-stream',       version: '1.5.8')
+    compile(group: 'com.netflix.hystrix',      name: 'hystrix-javanica',                   version: '1.5.8')
     compile(group: 'ch.qos.logback',           name: 'logback-access',                     version: '1.1.6')
     compile(group: 'ch.qos.logback',           name: 'logback-classic',                    version: '1.1.6')
     compile(group: 'org.slf4j',                name: 'slf4j-api',                          version: '1.7.7')
-    compile(group: 'com.bealetech',            name: 'metrics-statsd',                     version: '3.0.0-CAPGEMINI')
+    compile(group: 'com.bealetech',            name: 'metrics-statsd',                     version: '3.0.2')
     compile(group: 'com.capgemini',            name: 'codahale-metrics-filters',           version: '0.11.0')
     compile(group: 'com.capgemini',            name: 'springboot-camel-metrics-publisher', version: '0.12.0')
     compile(group: 'com.capgemini',            name: 'archaius-spring-adapter',            version: '0.10.2')
     compile(group: 'com.capgemini',            name: 'jetty-server-request-logger',        version: '0.9.0')
 
-    testCompile(group: 'junit',                    name: 'junit',                    version: '4.11')
+    testCompile(group: 'junit',                    name: 'junit',                    version: '4.12')
     testCompile(group: 'com.jayway.restassured',   name: 'rest-assured',             version: '2.4.1')
     testCompile(group: 'org.apache.camel',         name: 'camel-test-spring',        version: camelVersion)
     testCompile(group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: springBootVersion)
-    testCompile(group: 'javax.servlet',            name: 'javax.servlet-api',        version: '3.1.0') // TODO: this is a duplicate
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,6 @@ buildscript {
     }
     dependencies {
         classpath("org.springframework.boot:spring-boot-gradle-plugin:1.4.3.RELEASE")
-        classpath 'com.netflix.nebula:nebula-release-plugin:4.1.1'
     }
 }
 

--- a/src/integrationtest/java/com/capgemini/brahma/examples/route/RouteIntegrationTests.java
+++ b/src/integrationtest/java/com/capgemini/brahma/examples/route/RouteIntegrationTests.java
@@ -5,20 +5,22 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.boot.test.WebIntegrationTest;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit4.SpringRunner;
 
 import com.capgemini.brahma.Application;
 import com.jayway.restassured.RestAssured;
 
 import static com.jayway.restassured.RestAssured.when;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.DEFINED_PORT;
 
 /**
  * An example integraiton test which uses RESTAssured.
  */
-@RunWith(SpringJUnit4ClassRunner.class)
-@SpringApplicationConfiguration(classes = Application.class)
-@WebIntegrationTest("server.port:1111")
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = Application.class, webEnvironment= DEFINED_PORT)
 public class RouteIntegrationTests {
 
     @Before

--- a/src/main/java/com/capgemini/brahma/config/CamelHttpServletConfig.java
+++ b/src/main/java/com/capgemini/brahma/config/CamelHttpServletConfig.java
@@ -4,7 +4,7 @@ import org.apache.camel.component.servlet.CamelHttpTransportServlet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.context.embedded.ServletRegistrationBean;
+import org.springframework.boot.web.servlet.ServletRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 

--- a/src/main/java/com/capgemini/brahma/config/MyAppConfig.java
+++ b/src/main/java/com/capgemini/brahma/config/MyAppConfig.java
@@ -1,12 +1,14 @@
 package com.capgemini.brahma.config;
 
 import com.capgemini.archaius.spring.ArchaiusBridgePropertyPlaceholderConfigurer;
+import com.codahale.metrics.MetricRegistry;
 import org.apache.camel.CamelContext;
 import org.apache.camel.component.properties.PropertiesComponent;
 import org.apache.camel.spring.boot.CamelContextConfiguration;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
 
@@ -24,7 +26,7 @@ public class MyAppConfig {
      * @return the camel context
      */
     @Bean
-    CamelContextConfiguration contextConfiguration() {
+    CamelContextConfiguration contextConfiguration(MetricRegistry metricRegistry) {
         return new CamelContextConfiguration() {
             @Override
             public void beforeApplicationStart(CamelContext context) {
@@ -37,6 +39,10 @@ public class MyAppConfig {
                     context.setAllowUseOriginalMessage(Boolean.FALSE);
                 }
             }
+
+            @Override
+            public void afterApplicationStart(CamelContext camelContext) {
+            }
         };
     }
 
@@ -46,6 +52,7 @@ public class MyAppConfig {
      * @return the configurer
      */
     @Bean
+    @Primary
     public ArchaiusBridgePropertyPlaceholderConfigurer bridgePropertyPlaceholder() {
 
         ArchaiusBridgePropertyPlaceholderConfigurer configurer = new ArchaiusBridgePropertyPlaceholderConfigurer();


### PR DESCRIPTION
This resolves #40 

There have been a few changes, 

- `bridgePropertyPlaceholder` bean has to be marked as primary to avoid conflict with already existing `propertiesParser` bean
- `spring-boot` plugin name has changed to `org.springframework.boot`
- `junit` version was updated to 4.12
- `SpringJUnit4ClassRunner` has changed to `SpringRunner`
- `@SpringApplicationConfiguration` & `@WebIntegrationTest` have been combined to 1 annotation `@SpringBootTest`

Complete release notes for 1.4.3.RELEASE can be found [here](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-1.4-Release-Notes).
